### PR TITLE
Improve admin model editor usability

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -394,6 +394,57 @@ footer {
   margin-top: 1rem;
 }
 
+.model-selector {
+  margin-top: 1rem;
+}
+
+.model-selector .field {
+  margin-bottom: 0;
+}
+
+.model-selector-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.model-selector-row select {
+  flex: 1;
+  min-width: 220px;
+}
+
+.model-selector-row button {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.model-empty-message {
+  margin-top: 0.5rem;
+  color: var(--text-muted);
+}
+
+[data-models-container].is-interactive .model-card {
+  display: none;
+}
+
+[data-models-container].is-interactive .model-card.is-active {
+  display: block;
+}
+
+.model-card-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--accent-strong);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
 .model-card {
   border: 1px solid var(--border);
   border-radius: 14px;


### PR DESCRIPTION
## Summary
- Switch the admin pricing editor to a dropdown-driven workflow so only the selected model card is expanded at a time and labels stay in sync.
- Add helper utilities and data attributes for computing model labels and wiring the selection UI to existing card templates.
- Style the selector controls and active-card state to keep the form compact while maintaining clarity.

## Testing
- php -l admin.php
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68ce0415d6448327b3a369656b792cc7