### PR TITLE
Improve calculator interactions and layout

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -698,15 +698,21 @@ a:hover {
   margin-bottom: 1.3rem;
 }
 
-.model-list table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.95rem;
+.model-list .table-scroll {
   border-radius: 18px;
-  overflow: hidden;
   border: 1px solid rgba(148, 163, 184, 0.22);
   background: rgba(8, 20, 40, 0.55);
   backdrop-filter: blur(18px);
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+
+.model-list table {
+  width: 100%;
+  min-width: 640px;
+  border-collapse: collapse;
+  font-size: 0.95rem;
 }
 
 .model-list th,
@@ -1104,6 +1110,21 @@ footer::before {
   .results table th,
   .results table td {
     padding: 0.75rem;
+  }
+
+  .model-list .table-scroll {
+    margin: 0 -0.5rem;
+    border-radius: 14px;
+  }
+
+  .model-list table {
+    min-width: 560px;
+    font-size: 0.9rem;
+  }
+
+  .model-list th,
+  .model-list td {
+    padding: 0.6rem 0.75rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the calculator viewport steady by storing/restoring scroll position around model changes, calculations, and resets
- streamline the hero content by removing the model detail area and the JSON highlight button that edited pricing
- wrap the model pricing table in a horizontal scroll container with mobile-friendly spacing so it stays readable on phones

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68ce92586b188327838e1fb5136769bc