### PR TITLE
Disable browser caching for PHP pages and assets

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -3,6 +3,14 @@ declare(strict_types=1);
 
 session_start();
 
+$cacheControl = 'no-store, no-cache, must-revalidate, max-age=0';
+header('Cache-Control: ' . $cacheControl);
+header('Pragma: no-cache');
+header('Expires: 0');
+header('Surrogate-Control: no-store');
+
+$assetVersion = str_replace('.', '', sprintf('%.6F', microtime(true)));
+
 const SESSION_KEY = 'admin_authenticated';
 const DEFAULT_ADMIN_PASSWORD = 'price-edit';
 
@@ -311,8 +319,11 @@ if (!$authenticated) {
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="Cache-Control" content="<?= h($cacheControl) ?>">
+        <meta http-equiv="Pragma" content="no-cache">
+        <meta http-equiv="Expires" content="0">
         <title>料金設定管理 - ログイン</title>
-        <link rel="stylesheet" href="assets/styles.css">
+        <link rel="stylesheet" href="assets/styles.css?v=<?= h($assetVersion) ?>">
     </head>
     <body class="admin">
     <main class="narrow">
@@ -534,8 +545,11 @@ $modelCount = count($models);
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="<?= h($cacheControl) ?>">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     <title>料金設定管理</title>
-    <link rel="stylesheet" href="assets/styles.css">
+    <link rel="stylesheet" href="assets/styles.css?v=<?= h($assetVersion) ?>">
 </head>
 <body class="admin">
 <main>

--- a/index.php
+++ b/index.php
@@ -1,7 +1,14 @@
 <?php
 declare(strict_types=1);
 
+$cacheControl = 'no-store, no-cache, must-revalidate, max-age=0';
+header('Cache-Control: ' . $cacheControl);
+header('Pragma: no-cache');
+header('Expires: 0');
+header('Surrogate-Control: no-store');
+
 $dataPath = __DIR__ . '/data/pricing.json';
+$assetVersion = str_replace('.', '', sprintf('%.6F', microtime(true)));
 $error = null;
 $meta = [];
 $models = [];
@@ -182,8 +189,11 @@ $exchangeSourceText = trim((string) ($meta['exchange_rate_source'] ?? ''));
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="<?= h($cacheControl) ?>">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     <title>OpenAI API 料金計算ツール</title>
-    <link rel="stylesheet" href="assets/styles.css">
+    <link rel="stylesheet" href="assets/styles.css?v=<?= h($assetVersion) ?>">
 </head>
 <body class="calculator">
 <div class="page-gradient"></div>


### PR DESCRIPTION
## Summary
- send strict no-cache headers and matching meta tags from both the calculator and admin pages
- append a per-request cache-busting token to the shared stylesheet URL so browsers always fetch the latest styles

## Testing
- php -l index.php
- php -l admin.php

------
https://chatgpt.com/codex/tasks/task_e_68ce93d18db8832798ca7aebb052cbd0